### PR TITLE
feat(api): :sparkles: retrieving all the courses to which a client is…

### DIFF
--- a/@app/api/src/course/application/queries/paginatedSubscribedCourses/subscribedCourses.paginated.query.ts
+++ b/@app/api/src/course/application/queries/paginatedSubscribedCourses/subscribedCourses.paginated.query.ts
@@ -1,0 +1,63 @@
+import { ApplicationService } from 'src/core/application/service/application.service'
+import { Result } from 'src/core/application/result-handler/result.handler'
+import { CategoryRepository } from '../../repositories/category.repository'
+import { TrainerRepository } from '../../repositories/trainer.repository'
+import { ImageRepository } from '../../repositories/image.repository'
+import { GetSubscribedCoursesResponse } from './types/response'
+import { GetSubscribedCoursesDTO } from './types/dto'
+import { CourseRepository } from '../../repositories/course.repository'
+import { SubscriptionRepository } from '../../repositories/subscription.repository'
+import { Course } from 'src/course/application/models/course'
+
+export class GetSubscribedCoursesPaginatedQuery
+    implements
+        ApplicationService<
+            GetSubscribedCoursesDTO,
+            GetSubscribedCoursesResponse
+        >
+{
+    constructor(
+        private courseRepo: CourseRepository,
+        private trainerRepository: TrainerRepository,
+        private categoryRepo: CategoryRepository,
+        private imageRepository: ImageRepository,
+        private suscriptionRepo: SubscriptionRepository,
+    ) {}
+    async execute(
+        data: GetSubscribedCoursesDTO,
+    ): Promise<Result<GetSubscribedCoursesResponse>> {
+        const subscriptions = await this.suscriptionRepo.getManyByClientID(data)
+
+        const courses: Course[] = []
+
+        if (subscriptions) {
+            const coursePromises = subscriptions.map(async (subscription) => {
+                return this.courseRepo.getById(subscription.course)
+            })
+
+            const retrievedCourses = await Promise.all(coursePromises)
+
+            retrievedCourses.forEach((course) => {
+                if (course) {
+                    courses.push(course)
+                }
+            })
+        }
+
+        return Result.success(
+            await courses.asyncMap(async (course) => ({
+                id: course.id,
+                title: course.title,
+                description: course.description,
+                date: course.date,
+                category: (await this.categoryRepo.getById(course.category))!
+                    .name,
+                trainer: (await this.trainerRepository.getById(course.trainer))!
+                    .name,
+                image: (await this.imageRepository.getById(course.image))!.src,
+                progress: (await this.suscriptionRepo.getByCourseID(course.id))!
+                    .progress,
+            })),
+        )
+    }
+}

--- a/@app/api/src/course/application/queries/paginatedSubscribedCourses/types/dto.ts
+++ b/@app/api/src/course/application/queries/paginatedSubscribedCourses/types/dto.ts
@@ -1,0 +1,5 @@
+export class GetSubscribedCoursesDTO {
+    page: number
+    perPage: number
+    client: string
+}

--- a/@app/api/src/course/application/queries/paginatedSubscribedCourses/types/response.ts
+++ b/@app/api/src/course/application/queries/paginatedSubscribedCourses/types/response.ts
@@ -1,0 +1,11 @@
+export type GetSubscribedCoursesResponse = {
+    id: string
+    title: string
+    description: string
+    trainer: string
+    date: Date
+    updateDate?: Date
+    category: string
+    image: string
+    progress: number
+}[]

--- a/@app/api/src/course/application/repositories/subscription.repository.ts
+++ b/@app/api/src/course/application/repositories/subscription.repository.ts
@@ -1,10 +1,17 @@
 import { Optional } from '@mono/types-utils'
 import { Subscription } from '../models/subscription'
 
+export type GetManySuscriptionsData = {
+    page: number
+    perPage: number
+    client: string
+}
 export interface SubscriptionRepository {
     getById(id: string): Promise<Optional<Subscription>>
     getByCourseAndClient(
         courseId: string,
         clientId: string,
     ): Promise<Optional<Subscription>>
+    getManyByClientID(data: GetManySuscriptionsData): Promise<Subscription[]>
+    getByCourseID(courseID: string): Promise<Optional<Subscription>>
 }

--- a/@app/api/src/course/infraestructure/controllers/subscribed-courses-paginated/dto/getSubscribedCourses.dto.ts
+++ b/@app/api/src/course/infraestructure/controllers/subscribed-courses-paginated/dto/getSubscribedCourses.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { Type } from 'class-transformer'
+import { IsPositive, IsUUID, Min } from 'class-validator'
+
+export class GetSubscribedCoursesDTO {
+    @ApiProperty()
+    @Min(0)
+    @Type(() => Number)
+        page: number
+    @ApiProperty()
+    @IsPositive()
+    @Type(() => Number)
+        perPage: number
+    @ApiProperty({})
+    @IsUUID()
+        client: string
+}

--- a/@app/api/src/course/infraestructure/controllers/subscribed-courses-paginated/subscribed-courses-paginated.controller.ts
+++ b/@app/api/src/course/infraestructure/controllers/subscribed-courses-paginated/subscribed-courses-paginated.controller.ts
@@ -1,0 +1,52 @@
+import { Controller } from 'src/core/infraestructure/controllers/decorators/controller.module'
+import { COURSE_ROUTE_PREFIX, COURSE_DOC_PREFIX } from '../prefix'
+import { ControllerContract } from 'src/core/infraestructure/controllers/controller-model/controller.contract'
+import { Get, Query, UseGuards } from '@nestjs/common'
+import { UserGuard } from 'src/user/infraestructure/guards/user.guard'
+import { ApiHeader } from '@nestjs/swagger'
+import { CoursePostgresRepository } from '../../repositories/postgres/course.repository'
+import { ImagePostgresByCourseRepository } from '../../repositories/postgres/image.repository'
+import { TrainerPostgresByCourseRepository } from '../../repositories/postgres/trainer.repository'
+import { CategoryPostgresByCourseRepository } from '../../repositories/postgres/category.repository'
+import { GetSubscribedCoursesPaginatedQuery } from 'src/course/application/queries/paginatedSubscribedCourses/subscribedCourses.paginated.query'
+import { GetSubscribedCoursesDTO } from './dto/getSubscribedCourses.dto'
+import { GetSubscribedCoursesResponse } from 'src/course/application/queries/paginatedSubscribedCourses/types/response'
+import { SuscriptionPostgresByCourseRepository } from '../../repositories/postgres/suscription.repository'
+@Controller({
+    path: COURSE_ROUTE_PREFIX,
+    docTitle: COURSE_DOC_PREFIX,
+})
+export class subscribedCoursesController
+    implements
+        ControllerContract<
+            [data: GetSubscribedCoursesDTO],
+            GetSubscribedCoursesResponse
+        >
+{
+    constructor(
+        private courseRepository: CoursePostgresRepository,
+        private imageRepository: ImagePostgresByCourseRepository,
+        private trainerRepository: TrainerPostgresByCourseRepository,
+        private categoryRepository: CategoryPostgresByCourseRepository,
+        private subscriptionRepository: SuscriptionPostgresByCourseRepository,
+    ) {}
+
+    @Get('subscribedCourses')
+    @ApiHeader({
+        name: 'auth',
+    })
+    @UseGuards(UserGuard)
+    async execute(
+        @Query() data: GetSubscribedCoursesDTO,
+    ): Promise<GetSubscribedCoursesResponse> {
+        const result = await new GetSubscribedCoursesPaginatedQuery(
+            this.courseRepository,
+            this.categoryRepository,
+            this.trainerRepository,
+            this.imageRepository,
+            this.subscriptionRepository,
+        ).execute(data)
+
+        return result.unwrap()
+    }
+}

--- a/@app/api/src/course/infraestructure/repositories/postgres/suscription.repository.ts
+++ b/@app/api/src/course/infraestructure/repositories/postgres/suscription.repository.ts
@@ -1,0 +1,3 @@
+export class SuscriptionPostgresByCourseRepository{
+    
+}


### PR DESCRIPTION
… subscribed

it was added a query for retrieving all the courses to which a client is subscribed, and its controller. (the concrete repository for subscription is laking for its correct operation)