### PR TITLE
feat(api): :sparkles: all trainer event listeners, and new course eve…

### DIFF
--- a/@app/api/src/course/infraestructure/event-listeners/course-category-changed/course-category-changed.event.listener.ts
+++ b/@app/api/src/course/infraestructure/event-listeners/course-category-changed/course-category-changed.event.listener.ts
@@ -12,7 +12,7 @@ import { Category } from 'src/course/domain/entities/category'
 import { CategoryName } from 'src/course/domain/value-objects/category.name'
 
 @Injectable()
-export class courseCategoryChangedEventListener {
+export class CourseCategoryChangedEventListener {
     constructor(
         private eventHandle: RabbitMQEventHandler,
         @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,

--- a/@app/api/src/course/infraestructure/event-listeners/course-deleted/course-deleted.event.listener.ts
+++ b/@app/api/src/course/infraestructure/event-listeners/course-deleted/course-deleted.event.listener.ts
@@ -9,7 +9,7 @@ import {
 import { CourseID } from '../../../domain/value-objects/course.id'
 
 @Injectable()
-export class courseDeletedEventListener {
+export class CourseDeletedEventListener {
     constructor(
         private eventHandle: RabbitMQEventHandler,
         @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,

--- a/@app/api/src/course/infraestructure/event-listeners/course-description-changed/course-description-changed.event.listener.ts
+++ b/@app/api/src/course/infraestructure/event-listeners/course-description-changed/course-description-changed.event.listener.ts
@@ -10,7 +10,7 @@ import { CourseID } from '../../../domain/value-objects/course.id'
 import { CourseDescription } from 'src/course/domain/value-objects/course.description'
 
 @Injectable()
-export class courseDescriptionChangedEventListener {
+export class CourseDescriptionChangedEventListener {
     constructor(
         private eventHandle: RabbitMQEventHandler,
         @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,

--- a/@app/api/src/course/infraestructure/event-listeners/course-duration-changed/course-duration-changed.event.listener.ts
+++ b/@app/api/src/course/infraestructure/event-listeners/course-duration-changed/course-duration-changed.event.listener.ts
@@ -10,7 +10,7 @@ import { CourseID } from '../../../domain/value-objects/course.id'
 import { CourseDuration } from 'src/course/domain/value-objects/course.duration'
 
 @Injectable()
-export class courseDurationChangedEventListener {
+export class CourseDurationChangedEventListener {
     constructor(
         private eventHandle: RabbitMQEventHandler,
         @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,

--- a/@app/api/src/course/infraestructure/event-listeners/course-image-changed/course-image-changed.event.listener.ts
+++ b/@app/api/src/course/infraestructure/event-listeners/course-image-changed/course-image-changed.event.listener.ts
@@ -10,7 +10,7 @@ import { CourseID } from '../../../domain/value-objects/course.id'
 import { CourseImage } from 'src/course/domain/value-objects/course.image'
 
 @Injectable()
-export class courseImageChangedEventListener {
+export class CourseImageChangedEventListener {
     constructor(
         private eventHandle: RabbitMQEventHandler,
         @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,

--- a/@app/api/src/course/infraestructure/event-listeners/course-lesson-added/course-lesson-added.event.listener.ts
+++ b/@app/api/src/course/infraestructure/event-listeners/course-lesson-added/course-lesson-added.event.listener.ts
@@ -1,0 +1,44 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { DomainEventStorage } from 'src/core/application/event-storage/event.storage'
+import { RabbitMQEventHandler } from 'src/core/infraestructure/event-handler/rabbitmq/rabbit.service'
+import { MONGO_EVENT_STORAGE } from 'src/core/infraestructure/event-storage/mongo/mongo.event.storage.module'
+import {
+    COURSE_LESSON_ADDED,
+    courseLessonAdded,
+} from '../../../domain/events/course.lesson.added'
+import { CourseID } from 'src/course/domain/value-objects/course.id'
+import { Lesson } from 'src/course/domain/entities/lesson'
+import { LessonID } from 'src/course/domain/value-objects/lesson.id'
+import { LessonTitle } from 'src/course/domain/value-objects/lesson.title'
+import { LessonContent } from 'src/course/domain/value-objects/lesson.content'
+import { LessonVideo } from 'src/course/domain/value-objects/lesson.video'
+
+@Injectable()
+export class CourseLessonAddedEventListener {
+    constructor(
+        private eventHandle: RabbitMQEventHandler,
+        @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,
+    ) {
+        this.load()
+    }
+    load() {
+        this.eventHandle.listen(
+            COURSE_LESSON_ADDED,
+            (json) =>
+                courseLessonAdded({
+                    id: new CourseID(json.id._id),
+                    timestamp: new Date(json.timestamp),
+                    lesson: new Lesson(new LessonID(json.lesson._id._id), {
+                        title: new LessonTitle(json.lesson.data.title._title),
+                        content: new LessonContent(
+                            json.lesson.data.content._content,
+                        ),
+                        video: new LessonVideo(json.lesson.data.video._video),
+                    }),
+                }),
+            async (event) => {
+                await this.eventStorage.save(event)
+            },
+        )
+    }
+}

--- a/@app/api/src/course/infraestructure/event-listeners/course-lesson-removed/course-lesson-removed.event.listener.ts
+++ b/@app/api/src/course/infraestructure/event-listeners/course-lesson-removed/course-lesson-removed.event.listener.ts
@@ -1,0 +1,34 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { DomainEventStorage } from 'src/core/application/event-storage/event.storage'
+import { RabbitMQEventHandler } from 'src/core/infraestructure/event-handler/rabbitmq/rabbit.service'
+import { MONGO_EVENT_STORAGE } from 'src/core/infraestructure/event-storage/mongo/mongo.event.storage.module'
+import {
+    COURSE_LESSON_REMOVED,
+    courseLessonRemoved,
+} from '../../../domain/events/course.lesson.removed'
+import { CourseID } from 'src/course/domain/value-objects/course.id'
+import { LessonID } from 'src/course/domain/value-objects/lesson.id'
+
+@Injectable()
+export class CourseLessonRemovedEventListener {
+    constructor(
+        private eventHandle: RabbitMQEventHandler,
+        @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,
+    ) {
+        this.load()
+    }
+    load() {
+        this.eventHandle.listen(
+            COURSE_LESSON_REMOVED,
+            (json) =>
+                courseLessonRemoved({
+                    id: new CourseID(json.id._id),
+                    lesson: new LessonID(json.lesson._id._id),
+                    timestamp: new Date(json.timestamp),
+                }),
+            async (event) => {
+                await this.eventStorage.save(event)
+            },
+        )
+    }
+}

--- a/@app/api/src/trainer/application/commands/create/create.trainer.command.ts
+++ b/@app/api/src/trainer/application/commands/create/create.trainer.command.ts
@@ -9,6 +9,7 @@ import { trainerNameInvalidError } from '../../errors/trainer.name.invalid'
 import { TrainerID } from 'src/trainer/domain/value-objects/trainer.id'
 import { TrainerName } from 'src/trainer/domain/value-objects/trainer.name'
 import { TrainerLocation } from 'src/trainer/domain/value-objects/trainer.location'
+import { EventPublisher } from 'src/core/application/event-handler/event.handler'
 
 export class CreateTrainerCommand
     implements ApplicationService<CreateTrainerDto, CreateTrainerResponse>
@@ -16,6 +17,7 @@ export class CreateTrainerCommand
     constructor(
         private idGenerator: IDGenerator<string>,
         private trainerRepository: TrainerRepository,
+        private eventPublisher: EventPublisher,
     ) {}
     async execute(
         data: CreateTrainerDto,
@@ -31,6 +33,7 @@ export class CreateTrainerCommand
         })
         const result = await this.trainerRepository.save(trainer)
         if (result.isError()) return result.convertToOther()
+        this.eventPublisher.publish(trainer.pullEvents())
         return Result.success({
             id: trainerId,
         })

--- a/@app/api/src/trainer/domain/events/trainer.created.ts
+++ b/@app/api/src/trainer/domain/events/trainer.created.ts
@@ -8,7 +8,7 @@ export const TRAINER_CREATED = 'TRAINER_CREATED'
 
 export const trainerCreated = domainEventFactory<{
     id: TrainerID
-    name: TrainerName
+    _name: TrainerName
     location: TrainerLocation
     followers: ClientID[]
 }>(TRAINER_CREATED)

--- a/@app/api/src/trainer/domain/events/trainer.name.changed.ts
+++ b/@app/api/src/trainer/domain/events/trainer.name.changed.ts
@@ -6,5 +6,5 @@ export const TRAINER_NAME_CHANGED = 'TRAINER_NAME_CHANGED'
 
 export const trainerNameChanged = domainEventFactory<{
     id: TrainerID
-    name: TrainerName
+    _name: TrainerName
 }>(TRAINER_NAME_CHANGED)

--- a/@app/api/src/trainer/domain/trainer.ts
+++ b/@app/api/src/trainer/domain/trainer.ts
@@ -25,7 +25,8 @@ export class Trainer extends AggregateRoot<TrainerID> {
         this.publish(
             trainerCreated({
                 id,
-                ...data,
+                location: data.location,
+                _name: data.name,
                 followers: data.followers!,
             }),
         )
@@ -52,7 +53,7 @@ export class Trainer extends AggregateRoot<TrainerID> {
         this.publish(
             trainerNameChanged({
                 id: this.id,
-                name,
+                _name: name,
             }),
         )
     }

--- a/@app/api/src/trainer/infraestructure/controllers/create/creater-trainer.controller.ts
+++ b/@app/api/src/trainer/infraestructure/controllers/create/creater-trainer.controller.ts
@@ -16,6 +16,7 @@ import { AuditDecorator } from 'src/core/application/decorators/audit.decorator'
 import { AuditingTxtRepository } from 'src/core/infraestructure/auditing/repositories/txt/auditing.repository'
 import { User as UserDecorator } from 'src/user/infraestructure/decorators/user.decorator'
 import { CurrentUserResponse } from '../../../../../src/user/application/queries/current/types/response'
+import { RabbitMQEventHandler } from 'src/core/infraestructure/event-handler/rabbitmq/rabbit.service'
 
 @Controller({
     path: 'trainer',
@@ -32,6 +33,7 @@ export class CreateTrainerController
     constructor(
         @Inject(UUID_GEN_NATIVE) private idGen: IDGenerator<string>,
         private trainerRepo: TrainerPostgresRepository,
+        private eventPublisher: RabbitMQEventHandler,
     ) {}
 
     @Post()
@@ -51,7 +53,11 @@ export class CreateTrainerController
         const result = await new ErrorDecorator(
             new AuditDecorator(
                 new LoggerDecorator(
-                    new CreateTrainerCommand(this.idGen, this.trainerRepo),
+                    new CreateTrainerCommand(
+                        this.idGen,
+                        this.trainerRepo,
+                        this.eventPublisher,
+                    ),
                     new NestLogger('CreateTrainer'),
                 ),
                 new AuditingTxtRepository(),

--- a/@app/api/src/trainer/infraestructure/event-listeners/follower-added/follower-added.event.listener.ts
+++ b/@app/api/src/trainer/infraestructure/event-listeners/follower-added/follower-added.event.listener.ts
@@ -10,7 +10,7 @@ import { TrainerID } from 'src/trainer/domain/value-objects/trainer.id'
 import { ClientID } from 'src/trainer/domain/value-objects/client.id'
 
 @Injectable()
-export class followerAddedEventListener {
+export class FollowerAddedEventListener {
     constructor(
         private eventHandle: RabbitMQEventHandler,
         @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,

--- a/@app/api/src/trainer/infraestructure/event-listeners/follower-added/follower-added.event.listener.ts
+++ b/@app/api/src/trainer/infraestructure/event-listeners/follower-added/follower-added.event.listener.ts
@@ -1,0 +1,34 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { DomainEventStorage } from 'src/core/application/event-storage/event.storage'
+import { RabbitMQEventHandler } from 'src/core/infraestructure/event-handler/rabbitmq/rabbit.service'
+import { MONGO_EVENT_STORAGE } from 'src/core/infraestructure/event-storage/mongo/mongo.event.storage.module'
+import {
+    FOLLOWER_ADDED,
+    followerAdded,
+} from '../../../domain/events/follower.added'
+import { TrainerID } from 'src/trainer/domain/value-objects/trainer.id'
+import { ClientID } from 'src/trainer/domain/value-objects/client.id'
+
+@Injectable()
+export class followerAddedEventListener {
+    constructor(
+        private eventHandle: RabbitMQEventHandler,
+        @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,
+    ) {
+        this.load()
+    }
+    load() {
+        this.eventHandle.listen(
+            FOLLOWER_ADDED,
+            (json) =>
+                followerAdded({
+                    id: new TrainerID(json.id._id),
+                    follower: new ClientID(json.follower._id._id),
+                    timestamp: new Date(json.timestamp),
+                }),
+            async (event) => {
+                await this.eventStorage.save(event)
+            },
+        )
+    }
+}

--- a/@app/api/src/trainer/infraestructure/event-listeners/follower-removed/follower-removed.event.listener.ts
+++ b/@app/api/src/trainer/infraestructure/event-listeners/follower-removed/follower-removed.event.listener.ts
@@ -1,0 +1,34 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { DomainEventStorage } from 'src/core/application/event-storage/event.storage'
+import { RabbitMQEventHandler } from 'src/core/infraestructure/event-handler/rabbitmq/rabbit.service'
+import { MONGO_EVENT_STORAGE } from 'src/core/infraestructure/event-storage/mongo/mongo.event.storage.module'
+import {
+    FOLLOWER_REMOVED,
+    followerRemoved,
+} from '../../../domain/events/follower.removed'
+import { TrainerID } from 'src/trainer/domain/value-objects/trainer.id'
+import { ClientID } from 'src/trainer/domain/value-objects/client.id'
+
+@Injectable()
+export class FollowerRemovedEventListener {
+    constructor(
+        private eventHandle: RabbitMQEventHandler,
+        @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,
+    ) {
+        this.load()
+    }
+    load() {
+        this.eventHandle.listen(
+            FOLLOWER_REMOVED,
+            (json) =>
+                followerRemoved({
+                    id: new TrainerID(json.id._id),
+                    follower: new ClientID(json.follower._id),
+                    timestamp: new Date(json.timestamp),
+                }),
+            async (event) => {
+                await this.eventStorage.save(event)
+            },
+        )
+    }
+}

--- a/@app/api/src/trainer/infraestructure/event-listeners/trainer-created/trainer.created.event.listener.ts
+++ b/@app/api/src/trainer/infraestructure/event-listeners/trainer-created/trainer.created.event.listener.ts
@@ -1,0 +1,40 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { DomainEventStorage } from 'src/core/application/event-storage/event.storage'
+import { RabbitMQEventHandler } from 'src/core/infraestructure/event-handler/rabbitmq/rabbit.service'
+import { MONGO_EVENT_STORAGE } from 'src/core/infraestructure/event-storage/mongo/mongo.event.storage.module'
+import {
+    TRAINER_CREATED,
+    trainerCreated,
+} from 'src/trainer/domain/events/trainer.created'
+import { TrainerLocation } from 'src/trainer/domain/value-objects/trainer.location'
+import { TrainerID } from 'src/trainer/domain/value-objects/trainer.id'
+import { TrainerName } from 'src/trainer/domain/value-objects/trainer.name'
+import { ClientID } from 'src/trainer/domain/value-objects/client.id'
+
+@Injectable()
+export class TrainerCreatedEventListener {
+    constructor(
+        private eventHandle: RabbitMQEventHandler,
+        @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,
+    ) {
+        this.load()
+    }
+    load() {
+        this.eventHandle.listen(
+            TRAINER_CREATED,
+            (json) =>
+                trainerCreated({
+                    id: new TrainerID(json.id._id),
+                    _name: new TrainerName(json._name._name),
+                    location: new TrainerLocation(json.location._location),
+                    followers: (json.followers as Record<any, any>[]).map(
+                        (follower) => new ClientID(follower._id._id),
+                    ),
+                    timestamp: new Date(json.timestamp),
+                }),
+            async (event) => {
+                await this.eventStorage.save(event)
+            },
+        )
+    }
+}

--- a/@app/api/src/trainer/infraestructure/event-listeners/trainer-deleted/trainer-deleted.event.listener.ts
+++ b/@app/api/src/trainer/infraestructure/event-listeners/trainer-deleted/trainer-deleted.event.listener.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { DomainEventStorage } from 'src/core/application/event-storage/event.storage'
+import { RabbitMQEventHandler } from 'src/core/infraestructure/event-handler/rabbitmq/rabbit.service'
+import { MONGO_EVENT_STORAGE } from 'src/core/infraestructure/event-storage/mongo/mongo.event.storage.module'
+import {
+    TRAINER_DELETED,
+    trainerDeleted,
+} from '../../../domain/events/trainer.deleted'
+import { TrainerID } from 'src/trainer/domain/value-objects/trainer.id'
+
+@Injectable()
+export class TrainerDeletedEventListener {
+    constructor(
+        private eventHandle: RabbitMQEventHandler,
+        @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,
+    ) {
+        this.load()
+    }
+    load() {
+        this.eventHandle.listen(
+            TRAINER_DELETED,
+            (json) =>
+                trainerDeleted({
+                    id: new TrainerID(json.id._id),
+                    timestamp: new Date(json.timestamp),
+                }),
+            async (event) => {
+                await this.eventStorage.save(event)
+            },
+        )
+    }
+}

--- a/@app/api/src/trainer/infraestructure/event-listeners/trainer-location-changed/trainer-location-changed.event.listener.ts
+++ b/@app/api/src/trainer/infraestructure/event-listeners/trainer-location-changed/trainer-location-changed.event.listener.ts
@@ -1,0 +1,34 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { DomainEventStorage } from 'src/core/application/event-storage/event.storage'
+import { RabbitMQEventHandler } from 'src/core/infraestructure/event-handler/rabbitmq/rabbit.service'
+import { MONGO_EVENT_STORAGE } from 'src/core/infraestructure/event-storage/mongo/mongo.event.storage.module'
+import {
+    TRAINER_LOCATION_CHANGED,
+    trainerLocationChanged,
+} from '../../../domain/events/trainer.location.changed'
+import { TrainerID } from 'src/trainer/domain/value-objects/trainer.id'
+import { TrainerLocation } from 'src/trainer/domain/value-objects/trainer.location'
+
+@Injectable()
+export class TrainerLocationChangedEventListener {
+    constructor(
+        private eventHandle: RabbitMQEventHandler,
+        @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,
+    ) {
+        this.load()
+    }
+    load() {
+        this.eventHandle.listen(
+            TRAINER_LOCATION_CHANGED,
+            (json) =>
+                trainerLocationChanged({
+                    id: new TrainerID(json.id._id),
+                    location: new TrainerLocation(json.location._location),
+                    timestamp: new Date(json.timestamp),
+                }),
+            async (event) => {
+                await this.eventStorage.save(event)
+            },
+        )
+    }
+}

--- a/@app/api/src/trainer/infraestructure/event-listeners/trainer-name-changed/trainer-name-changed.event.listener.ts
+++ b/@app/api/src/trainer/infraestructure/event-listeners/trainer-name-changed/trainer-name-changed.event.listener.ts
@@ -1,0 +1,34 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { DomainEventStorage } from 'src/core/application/event-storage/event.storage'
+import { RabbitMQEventHandler } from 'src/core/infraestructure/event-handler/rabbitmq/rabbit.service'
+import { MONGO_EVENT_STORAGE } from 'src/core/infraestructure/event-storage/mongo/mongo.event.storage.module'
+import {
+    TRAINER_NAME_CHANGED,
+    trainerNameChanged,
+} from '../../../domain/events/trainer.name.changed'
+import { TrainerID } from 'src/trainer/domain/value-objects/trainer.id'
+import { TrainerName } from 'src/trainer/domain/value-objects/trainer.name'
+
+@Injectable()
+export class TrainerNameChangedEventListener {
+    constructor(
+        private eventHandle: RabbitMQEventHandler,
+        @Inject(MONGO_EVENT_STORAGE) private eventStorage: DomainEventStorage,
+    ) {
+        this.load()
+    }
+    load() {
+        this.eventHandle.listen(
+            TRAINER_NAME_CHANGED,
+            (json) =>
+                trainerNameChanged({
+                    id: new TrainerID(json.id._id),
+                    _name: new TrainerName(json._name._name),
+                    timestamp: new Date(json.timestamp),
+                }),
+            async (event) => {
+                await this.eventStorage.save(event)
+            },
+        )
+    }
+}

--- a/@app/api/tests/unit/suits/trainer/tests/create-trainer.test.ts
+++ b/@app/api/tests/unit/suits/trainer/tests/create-trainer.test.ts
@@ -3,6 +3,7 @@ import { TrainerRepositoryMock } from './utils/trainer.repository.mock'
 import { CreateTrainerCommand } from '../../../../../src/trainer/application/commands/create/create.trainer.command'
 import { IDGeneratorMock } from './utils/id.generator.mock'
 import { TrainerID } from '../../../../../src/trainer/domain/value-objects/trainer.id'
+import { eventPublisherStub } from './utils/event.publisher.stup'
 
 export const name = 'Should create trainer with valid data'
 export const body = async () => {
@@ -15,6 +16,7 @@ export const body = async () => {
     const result = await new CreateTrainerCommand(
         new IDGeneratorMock(trainerId),
         trainerRepo,
+        eventPublisherStub,
     ).execute(trainerData)
     lookFor(result.isError()).equals(false)
     const trainer = await trainerRepo.getById(new TrainerID(trainerId))

--- a/@app/api/tests/unit/suits/trainer/tests/not-create-trainer-name-exists.test.ts
+++ b/@app/api/tests/unit/suits/trainer/tests/not-create-trainer-name-exists.test.ts
@@ -4,6 +4,7 @@ import { IDGeneratorMock } from './utils/id.generator.mock'
 import { TrainerRepositoryMock } from './utils/trainer.repository.mock'
 import { TRAINER_NAME_INVALID } from '../../../../../src/trainer/application/errors/trainer.name.invalid'
 import { createTrainer } from './utils/trainer.factory'
+import { eventPublisherStub } from './utils/event.publisher.stup'
 
 export const name = 'Should not create trainer with an existing name'
 
@@ -20,6 +21,7 @@ export const body = async () => {
     const result = await new CreateTrainerCommand(
         new IDGeneratorMock(),
         trainerRepo,
+        eventPublisherStub,
     ).execute(trainerData)
     result.handleError((e) => {
         lookFor(e.name).equals(TRAINER_NAME_INVALID)

--- a/@app/api/tests/unit/suits/trainer/tests/utils/event.publisher.stup.ts
+++ b/@app/api/tests/unit/suits/trainer/tests/utils/event.publisher.stup.ts
@@ -1,0 +1,11 @@
+import { EventPublisher } from '../../../../../../src/core/application/event-handler/event.handler'
+import { DomainEventBase } from '../../../../../../src/core/domain/events/event'
+
+export const eventPublisherStub = {
+    events: [],
+    publish(events) {
+        this.events = events
+    },
+} satisfies EventPublisher & {
+    events: DomainEventBase[]
+}


### PR DESCRIPTION
I had to do one change in the trainerCreated event ( name  -> _name ) because the name property of the event (TrainerName) overrides the property coming from DomainEventBase type, and changes the name of the event, assigning an object to a property of the string type.